### PR TITLE
Update userInfoUrl in app.yml

### DIFF
--- a/src/main/resources/app.yml
+++ b/src/main/resources/app.yml
@@ -2,4 +2,4 @@ oauth:
   clientId: <clientId>
   clientSecret: <clientSecret>
   checkTokenUrl: https://www.googleapis.com/oauth2/v3/tokeninfo?access_token={accessToken}
-  userInfoUrl: https://www.googleapis.com/plus/v1/people/me
+  userInfoUrl: https://www.googleapis.com/userinfo/v2/me


### PR DESCRIPTION
The original URL https://www.googleapis.com/plus/v1/people/me is not working anymore, you get a FORBIDDEN response. 

- Change userInfoUrl to working https://www.googleapis.com/userinfo/v2/me

Also see https://stackoverflow.com/questions/54473043/deprecation-of-https-www-googleapis-com-plus-v1-people-me-and-how-properly-to